### PR TITLE
Added UaClientSdk namespace to all of UaSession

### DIFF
--- a/supplementary_include/CalculatedVariable.h
+++ b/supplementary_include/CalculatedVariable.h
@@ -18,7 +18,7 @@ class CalculatedVariable
 public:
 
     CalculatedVariable(
-        UaSession* session,
+        UaClientSdk::UaSession* session,
         UaNodeId objId
     );
 
@@ -31,12 +31,11 @@ public:
 
 private:
 
-    UaSession  * m_session;
-    UaNodeId     m_objId;
+    UaClientSdk::UaSession* m_session;
+    UaNodeId                m_objId;
 
 };
 
 
 
 }
-

--- a/supplementary_src/CalculatedVariable.cpp
+++ b/supplementary_src/CalculatedVariable.cpp
@@ -17,7 +17,7 @@ namespace UaoClient
 CalculatedVariable::
 CalculatedVariable
 (
-    UaSession* session,
+    UaClientSdk::UaSession* session,
     UaNodeId objId
 ) :
     m_session(session),
@@ -86,5 +86,3 @@ OpcUa_Double CalculatedVariable::readValue (
 
 
 }
-
-

--- a/templates/designToClassBody.jinja
+++ b/templates/designToClassBody.jinja
@@ -131,7 +131,7 @@ namespace {{namespace}}
 {{className}}::
 {{className}}
 (
-  UaSession* session,
+  UaClientSdk::UaSession* session,
   UaNodeId objId
   ) :
   m_session(session),

--- a/templates/designToClassHeader.jinja
+++ b/templates/designToClassHeader.jinja
@@ -38,7 +38,7 @@ class {{className}}
 public:
 
   {{className}}(
-    UaSession* session,
+    UaClientSdk::UaSession* session,
     UaNodeId objId
   );
 
@@ -90,8 +90,8 @@ public:
 
 private:
 
-  UaSession  * m_session;
-  UaNodeId     m_objId;
+  UaClientSdk::UaSession* m_session;
+  UaNodeId                m_objId;
 
 };
 


### PR DESCRIPTION
The motivation for it is that UaSession is a class name both in server and client SDK. For certain projects that integrate both UA server and client it helps to be more explicit there otherwise under many circumstances the compiler can't resolve what we're talking about.