### PR TITLE
Adding proper .h include in UaoExceptions.cpp

### DIFF
--- a/supplementary_src/UaoExceptions.cpp
+++ b/supplementary_src/UaoExceptions.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <sstream>
+#include "UaoExceptions.h"
 
 namespace UaoClient
 {


### PR DESCRIPTION
adding missing #include "UaoExceptions.h"